### PR TITLE
Adding option to add Progress handler to copy_table operation; Also adding option to set progress_handler positional arguments

### DIFF
--- a/easy_db/database.py
+++ b/easy_db/database.py
@@ -153,7 +153,7 @@ class DataBase():
 
                 if progress_handler is not None:
                     if self.db_type == 'SQLITE3':  # progress_handler only currently working for sqlite
-                        conn.set_progress_handler(progress_handler, 100)  # Can use to track progress
+                        conn.set_progress_handler(*progress_handler if type(progress_handler) is tuple else (progress_handler, 100)) # Can use to track progress
                     else:
                         print('progress_handler is only available for use with a SQLite database.')
 

--- a/easy_db/database.py
+++ b/easy_db/database.py
@@ -382,13 +382,13 @@ class DataBase():
         print(f'Data inserted in "{tablename}" -> {"{:,.0f}".format(original_data_len)} rows')
 
 
-    def copy_table(self, other_easydb, tablename: str, new_tablename: str='', column_case: str='same'):
+    def copy_table(self, other_easydb, tablename: str, new_tablename: str='', column_case: str='same', progress_handler=None):
         '''
         Copy specified table from other easy_db.DataBase to this DB.
         If desired, column names can be set to be all upper or lower-case
         via column_case kwarg ('upper' = UPPERCASE and 'lower' lowercase)
         '''
-        data = other_easydb.pull_table(tablename, clear_cache=True)  # clearing cache to ensure fresh pull
+        data = other_easydb.pull_table(tablename, clear_cache=True, progress_handler=progress_handler)  # clearing cache to ensure fresh pull
         if column_case.lower() == 'lower':
             columns_and_types = {key.lower(): val for key, val in other_easydb.table_columns_and_types(tablename).items()}
             table_data = [{col.lower(): val for col, val in d.items()} for d in data]


### PR DESCRIPTION
I fixed the pull request. This should allow the user to add progress handlers to the copy_table operation, just like we can do with the pull_table.

ALSO:
I added the option for the client to set the N argument that gets passed to the set_progress_handler.